### PR TITLE
Add Azure storage account upload support

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,6 +10,8 @@ RUN pip install google-cloud-storage
 RUN pip install boto3
 RUN pip install azure-storage-blob
 
+RUN apk del build-base
+
 RUN git clone https://github.com/vulnersCom/nmap-vulners /usr/share/nmap/scripts/vulners
 RUN nmap --script-updatedb
 RUN mkdir /shared

--- a/README.md
+++ b/README.md
@@ -51,16 +51,16 @@ $ docker run -v $(shell pwd)/shared:/shared flan_scan <Nmap-flags>
 Pushing Results to the Cloud
 ----------------------------
 
-Flan Scan currently supports pushing Latex reports and raw XML Nmap output files to a GCS Bucket or to an AWS S3 Bucket. Flan Scan requires 2 environment variables to push results to the cloud. The first is `upload` which takes one of two values `gcp` or `aws`. The second is `bucket` and the value is the name of the S3 or GCS Bucket to upload the results to. To set the environment variables, after running `make build` run the container setting the environment variables like so:
+Flan Scan currently supports pushing Latex reports and raw XML Nmap output files to a GCS Bucket, AWS S3 Bucket, or an Azure Storage account. Flan Scan requires 2 environment variables to push results to the cloud. The first is `upload` which takes one of three values `gcp` or `aws` or `az`. The second is `bucket` and the value is the name of the S3 or GCS Bucket or Azure Container to upload the results to. To set the environment variables, after running `make build` run the container setting the environment variables like so:
 ```bash
 $ docker run --name <container-name> \
              -v $(pwd)/shared:/shared \
-             -e upload=<gcp or aws> \
+             -e upload=<gcp or aws or az> \
              -e bucket=<bucket-name> \
              flan_scan
 ```
 
-Below are some examples for adding the necessary AWS or GCP authentication keys as environment variables in container. However, this can also be accomplished with a secret in Kubernetes that exposes the necessary environment variables or with other secrets management tools.
+Below are some examples for adding the necessary AWS, GCP, or Azure authentication keys as environment variables in container. However, this can also be accomplished with a secret in Kubernetes that exposes the necessary environment variables or with other secrets management tools.
 
 
 ### Example GCS Bucket Configuration

--- a/az_push.py
+++ b/az_push.py
@@ -9,8 +9,12 @@ account_key = os.getenv('AZURE_ACCOUNT_KEY')
 container_name = os.getenv('bucket')
 
 try:
-    blob_service_client = BlobServiceClient(account_url=account_url, credential=account_key)
-    blob_client = blob_service_client.get_blob_client(container=container_name, blob=filename)
+    blob_service_client = BlobServiceClient(
+        account_url=account_url, credential=account_key
+    )
+    blob_client = blob_service_client.get_blob_client(
+        container=container_name, blob=filename
+    )
 
     with open(filename, "rb") as data:
         blob_client.upload_blob(data)

--- a/output_report.py
+++ b/output_report.py
@@ -196,6 +196,10 @@ def create_latex(nmap_command, start_date):
     latex_file.write(write_buffer)
     latex_file.close()
 
+def parse_nmap_command(raw_command):
+    nmap_split = raw_command.split()[:-1] #remove last element, ip address
+    nmap_split[3] = "<output-file>"
+    return " ".join(nmap_split)
 
 def main():
     dirname = sys.argv[1]
@@ -207,10 +211,7 @@ def main():
         data = xmltodict.parse(xml_content)
         parse_results(data)
         if i == 0:
-            nmap_wo_last_word = data['nmaprun']['@args'].rsplit(' ', 1)[0]
-            nmap_split = nmap_wo_last_word.split()
-            nmap_split[3] = "<output-file>"
-            nmap_command = " ".join(nmap_split)
+            nmap_command = parse_nmap_command(data['nmaprun']['@args'])
             start_date = data['nmaprun']['@startstr']
 
     create_latex(nmap_command, start_date)


### PR DESCRIPTION
This change adds support for uploading scan reports to Azure storage accounts.  

The primary downside to this change is that the Azure python packages have a dependency on cffi, which performs a compile when installed in alpine.  Thus, it requires gcc and some other support libraries to complete installation. `build-base` is removed again after the pip installations complete.