### PR TITLE
Escape the % symbol in the output report

### DIFF
--- a/run.sh
+++ b/run.sh
@@ -43,4 +43,5 @@ python /output_report.py $root_dir$xml_dir $root_dir$report_file /shared/ips.txt
 sed -i 's/_/\\_/g' $root_dir$report_file
 sed -i 's/\$/\\\$/g' $root_dir$report_file
 sed -i 's/#/\\#/g' $root_dir$report_file
+sed -i 's/%/\\%/g' $root_dir$report_file
 upload $report_file


### PR DESCRIPTION
LaTeX considers % as a comment-till-end-of-line marker,
my sendmail version number had a % in it