### PR TITLE
Docker image without apk/pip cache

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,8 @@
 FROM python:3.5-alpine
 
-RUN apk add nmap nmap-scripts git
+RUN apk add --no-cache nmap nmap-scripts git
 
-RUN pip install xmltodict google-cloud-storage boto3
+RUN pip install --no-cache-dir xmltodict google-cloud-storage boto3
 
 RUN git clone https://github.com/vulnersCom/nmap-vulners /usr/share/nmap/scripts/vulners && nmap --script-updatedb
 RUN mkdir /shared


### PR DESCRIPTION
`apk` and `pip` creates local cache. In case of docker image we don't need that cache to ship with image.

Docker image size change:
`apk --no-cache` - 1MB smaller
`pip --no-cache-dir` - 10MB smaller

Finale result: `206MB` -> `195MB`