### PR TITLE
Add extrafloats and maxdeadcycles avoiding LaTeX errors in large reports

### DIFF
--- a/latex_header.tex
+++ b/latex_header.tex
@@ -7,6 +7,8 @@
 \usepackage{hyperref}
 \usepackage{fontawesome}
 \usepackage{listings}
+\extrafloats{600}
+\maxdeadcycles 600
 \lstset{
 basicstyle=\small\ttfamily,
 columns=flexible,


### PR DESCRIPTION
Added extrafloats  in latex header to avoid "LaTeX Error: Too many unprocessed floats".
Added maxdeadcycles in latex header to avoid "Output loop---100 consecutive dead cycles".

The value 600 for both settings is debatable but in multiple test it has proven large enough to fix the errors without maxing the latex compiler memory. These values can be adjusted upwards if needed.