### PR TITLE
Update Makefile for SELinux

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,4 +3,4 @@ build :
 
 container_name = flan_$(shell date +'%s')
 start : 
-	docker run --name $(container_name) -v $(shell pwd)/shared:/shared flan_scan
+	docker run --name $(container_name) -v $(shell pwd)/shared:/shared:Z flan_scan


### PR DESCRIPTION
Added a label :Z, because without it it does not work for CentOS7 with SELinux enabled - it cannot write files to the /shared/ directory

Details:
https://www.mankier.com/8/docker_selinux
http://manpages.org/docker-run
https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux_atomic_host/7/html/container_security_guide/docker_selinux_security_policy