### PR TITLE
Dockerfile linting, reduce image size and container privileges

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,16 +1,15 @@
-FROM python:3.5-alpine
+FROM python:3.6-alpine
 
-RUN apk add --no-cache nmap nmap-scripts git
-COPY requirements.txt /
-RUN pip install --no-cache-dir -r requirements.txt
-
-RUN git clone https://github.com/vulnersCom/nmap-vulners /usr/share/nmap/scripts/vulners && nmap --script-updatedb
-RUN mkdir /shared
-
-COPY run.sh output_report.py gcp_push.py aws_push.py /
+COPY aws_push.py gcp_push.py output_report.py requirements.txt run.sh /
 COPY contrib /contrib
 COPY shared /shared
 
-RUN chmod +x /run.sh
+RUN apk add --no-cache nmap nmap-scripts git && \
+    pip install --no-cache-dir -r requirements.txt && \
+    git clone https://github.com/vulnersCom/nmap-vulners \
+      /usr/share/nmap/scripts/vulners && \
+    nmap --script-updatedb && \
+    apk del git && \
+    chmod +x /run.sh
 
-ENTRYPOINT ["/run.sh"]
+ENTRYPOINT ["/bin/sh","-c","/run.sh"]

--- a/Makefile
+++ b/Makefile
@@ -1,15 +1,15 @@
-build : 
-	docker build -t flan_scan .
+build :
+	docker build --no-cache -t flan_scan .
 
 container_name = flan_$(shell date +'%s')
-start : 
-	docker run --name $(container_name) -v "$(CURDIR)/shared:/shared:Z" flan_scan
+start :
+	docker run --rm --cap-drop=all --cap-add=NET_RAW --name $(container_name) -v "$(CURDIR)/shared:/shared:Z" flan_scan
 
 md :
-	docker run --name $(container_name) -v "$(CURDIR)/shared:/shared:Z" -e format=md flan_scan
+	docker run --rm --cap-drop=all --cap-add=NET_RAW --name $(container_name) -v "$(CURDIR)/shared:/shared:Z" -e format=md flan_scan
 
 html :
-	docker run --name $(container_name) -v "$(CURDIR)/shared:/shared:Z" -e format=html flan_scan
+	docker run --rm --cap-drop=all --cap-add=NET_RAW --name $(container_name) -v "$(CURDIR)/shared:/shared:Z" -e format=html flan_scan
 
 json :
-	docker run --name $(container_name) -v "$(CURDIR)/shared:/shared:Z" -e format=json flan_scan
+	docker run --rm --cap-drop=all --cap-add=NET_RAW --name $(container_name) -v "$(CURDIR)/shared:/shared:Z" -e format=json flan_scan


### PR DESCRIPTION
Hi,
this PR aims to:
- reduce the Docker image size (~20M)
- update to `python:3.6-alpine`
- reduce `RUN` and `COPY` commands to minimize the number of layers

Modification to the `Makefile`:
- `make build` now ignores cache to keep the image up-to-date
- containers are removed after usage
- container capabilites are dropped, and only `NET_RAW` is allowed