### PR TITLE
Removes trailing whitespace in Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,8 +1,8 @@
-build : 
+build :
 	docker build -t flan_scan .
 
 container_name = flan_$(shell date +'%s')
-start : 
+start :
 	docker run --name $(container_name) -v "$(CURDIR)/shared:/shared:Z" flan_scan
 
 md :


### PR DESCRIPTION
Removes the trailing whitespace after the "build :" and "start :" options.