### PR TITLE
Fixes uncaught exception

### DIFF
--- a/contrib/parsers/flan_xml_parser.py
+++ b/contrib/parsers/flan_xml_parser.py
@@ -85,7 +85,10 @@ class FlanXmlParser:
         if port['state']['@state'] == 'closed':
             return
 
-        app_name = self.get_app_name(port['service'])
+        try:
+            app_name = self.get_app_name(port['service'])
+        except KeyError:
+            app_name = "unknown"
         port_num = port['@portid']
         new_app = app_name not in self.results
         self.results[app_name].locations[ip_addr].append(port_num)


### PR DESCRIPTION
If Nmap failed to detect a service, the execution will break with traceback

```
Traceback (most recent call last):
  File "/output_report.py", line 81, in <module>
    main(*sys.argv[1:4], report_type=report_format)
  File "/output_report.py", line 71, in main
    parser.parse(data)
  File "/contrib/parsers/flan_xml_parser.py", line 55, in parse
    self.parse_host(hosts)
  File "/contrib/parsers/flan_xml_parser.py", line 120, in parse_host
    self.parse_port(ip_addr, p)
  File "/contrib/parsers/flan_xml_parser.py", line 88, in parse_port
    app_name = self.get_app_name(port['service'])
KeyError: 'service'
```

This small PR just catches that exception and replace any unknown service with the word 'unknown'. 