### PR TITLE
Bump alpine version.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.5-alpine
+FROM python:3.9.1-alpine
 
 RUN apk add --no-cache nmap nmap-scripts git
 COPY requirements.txt /


### PR DESCRIPTION
Vulnerability scanner running on [EOL](https://endoflife.date/python) python:3.5-alpine image


```
OK: 51 MiB in 38 packages
Removing intermediate container 688747be7323
 ---> 7baa120e0ba4
Step 3/11 : COPY requirements.txt /
 ---> 09416ee02c55
Step 4/11 : RUN pip install --no-cache-dir -r requirements.txt
 ---> Running in bfb7b3baa9fa
DEPRECATION: Python 3.5 reached the end of its life on September 13th, 2020. Please upgrade your Python as Python 3.5 is no longer maintained. pip 21.0 will drop support for Python 3.5 in January 2021. pip 21.0 will remove support for this functionality.
```

Tested locally

```
vagrant@mylocal:~/flan$ sudo make json
docker run --name flan_1612534098 -v "/home/vagrant/flan/shared:/shared:Z" -e format=json flan_scan
# Nmap 7.91 scan initiated Fri Feb  5 14:08:18 2021 as: nmap -sV -oX /shared/xml_files/2021.02.05-14.08/127.0.0.1.xml -oN - -v1 --script=vulners/vulners.nse 127.0.0.1
Nmap scan report for localhost (127.0.0.1)
Host is up (0.0000020s latency).
All 1000 scanned ports on localhost (127.0.0.1) are closed

Read data files from: /usr/bin/../share/nmap
Service detection performed. Please report any incorrect results at https://nmap.org/submit/ .
# Nmap done at Fri Feb  5 14:08:19 2021 -- 1 IP address (1 host up) scanned in 0.38 seconds
vagrant@mylocal:~/flan$ cat Dockerfile
FROM python:3.9.1-alpine

RUN apk add --no-cache nmap nmap-scripts git
COPY requirements.txt /
RUN pip install --no-cache-dir -r requirements.txt

RUN git clone https://github.com/vulnersCom/nmap-vulners /usr/share/nmap/scripts/vulners && nmap --script-updatedb
RUN mkdir /shared

COPY run.sh output_report.py gcp_push.py aws_push.py /
COPY contrib /contrib
COPY shared /shared

RUN chmod +x /run.sh

ENTRYPOINT ["/run.sh"]```