### PR TITLE
Added in extrafloats and maxdeadcycles per PR #36

### DIFF
--- a/contrib/report_builders/latex_report_builder.py
+++ b/contrib/report_builders/latex_report_builder.py
@@ -109,6 +109,8 @@ class LatexReportBuilder(ReportBuilder):
 \usepackage{hyperref}
 \usepackage{fontawesome}
 \usepackage{listings}
+\extrafloats{600}
+\maxdeadcycles 600
 \lstset{
 basicstyle=\small\ttfamily,
 columns=flexible,


### PR DESCRIPTION
PR #36 contained changes to a file that no longer exists (latex_header.tex) therefore we were unable to merge due to conflicts. I created a new pull request that adds the same parameters to the pertinent file (contrib/report_builders/latex_report_builder.py).