### PR TITLE
fix markupsafe dependency issue

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,3 +2,4 @@ xmltodict==0.12.0
 google-cloud-storage==1.23.0
 boto3==1.12.15
 Jinja2==2.11.3
+markupsafe==2.0.1


### PR DESCRIPTION
dependency is broken. 
```ImportError: cannot import name 'soft_unicode' from 'markupsafe'``` 
 
same problem as 
https://github.com/pallets/markupsafe/issues/284

set markupsafe==2.0.1 will fix the issue